### PR TITLE
Defining ARDUINO_SAMD_NANO_33_IOT in the variant.h file of the HabiTr…

### DIFF
--- a/hardware/samd/0.1.0/variants/habitrak_v1_1/variant.h
+++ b/hardware/samd/0.1.0/variants/habitrak_v1_1/variant.h
@@ -428,4 +428,7 @@ extern Uart SerialHCI;
 // Alias Serial to SerialUSB
 #define SerialUSB                   Serial
 
+//This define is needed for the ArduinoBLE and WiFiNINA libraries to fully function properly.
+#define ARDUINO_SAMD_NANO_33_IOT
+
 #endif /* _VARIANT_HABITRAK_V1_1_ */


### PR DESCRIPTION
…ak 1.1 board. This define statement is needed for the ArduinoBLE and WiFiNINA libraries to fully function properly.